### PR TITLE
feat: switch statement support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'quotes': ['error', 'single'],
     'linebreak-style': ['error', 'unix'],
     'semi': ['error', 'always'],
-    'indent': ['error', 2],
+    'indent': ['error', 2, { 'SwitchCase': 1 }],
     'radix': 1,
     'eol-last': ['error', 'always'],
     'consistent-return': 1,


### PR DESCRIPTION
Will resolve some linting errors discussed in https://github.com/os-js/osjs-server/pull/67.

The addition of the `.gitignore` is necessary for opening the repo in GitHub Codespaces, because it automatically downloads dependencies.